### PR TITLE
Quality of Life Improvements and Flake8 Linting

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -6,6 +6,9 @@
     {
         "keys": ["alt+shift+c"],
         "command": "q_color_converter"
-    }
-
+    },
+    {
+        "keys": ["alt+ctrl+c"],
+        "command": "q_color_show",
+    },
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -6,6 +6,10 @@
     {
         "keys": ["alt+shift+c"],
         "command": "q_color_converter"
-    }
+    },
+    {
+        "keys": ["alt+ctrl+c"],
+        "command": "q_color_show",
+    },
 
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -6,6 +6,9 @@
     {
         "keys": ["alt+shift+c"],
         "command": "q_color_converter"
-    }
-
+    },
+    {
+        "keys": ["alt+ctrl+c"],
+        "command": "q_color_show",
+    },
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,99 +1,42 @@
-[
-  {
-    "caption": "Tools",
-    "id": "tools",
-    "mnemonic": "t",
+[{
+  "caption": "Tools",
+  "id": "tools",
+  "children": [{
+    "caption": "QColor",
     "children": [
-    {
+      // { "caption":"Debug", "command":"q_color_debug", "checkbox":true },
+      { "caption":"Enabled", "command":"q_color_enabled", "checkbox":true },
+      { "caption":"Show", "command":"q_color_show", "checkbox":true },
+      { "caption":"Picker", "command":"q_color_picker" },
+      { "caption":"Converter", "command":"q_color_converter" },
+      { "caption":"-", "id":"settings" },
+      { "caption":"Settings", "command":"edit_settings", "args":{"base_file":"${packages}/QColor/QColor.sublime-settings", "default":"{\n\t$0\n}\n" }},
+      { "caption":"Settings – Default", "command":"open_file", "args":{"file":"${packages}/QColor/QColor.sublime-settings" }},
+      { "caption":"Settings – User", "command":"open_file", "args":{"file":"${packages}/User/QColor.sublime-settings" }},
+      { "caption":"-", "id":"keymap" },
+      { "caption":"Key Bindings", "command":"edit_settings", "args":{"base_file":"${packages}/QColor/Default (${platform}).sublime-keymap", "default":"[\n\t$0\n]\n" }},
+      { "caption":"-", "id":"info" },
+      { "command":"q_color_version" },
+    ]
+  }]
+},{
+  "id": "preferences",
+  "mnemonic": "p",
+  "children": [{
+    "caption": "Package Settings",
+    "mnemonic": "P",
+    "id": "package-settings",
+    "children": [{
       "caption": "QColor",
-      // "id": "q_color",
-      "mnemonic": "c",
-      "children": [
-        // { "caption": "Debug", "command": "q_color_debug", "checkbox": true },
-        { "caption": "Enabled", "command": "q_color_enabled", "checkbox": true },
-        { "caption": "Show", "command": "q_color_show", "checkbox": true },
-        { "caption": "Picker", "command": "q_color_picker" },
-        { "caption": "Converter", "command": "q_color_converter" },
-
-        { "caption": "-", "id": "settings" },
-        {
-          "caption": "Settings",
-          "command": "edit_settings",
-          "args":
-          {
-            "base_file": "${packages}/QColor/QColor.sublime-settings",
-            "default": "{\n\t$0\n}\n"
-          }
-        },
-        {
-          "caption": "Settings – Default",
-          "command": "open_file",
-          "args": { "file": "${packages}/QColor/QColor.sublime-settings" }
-        },
-        {
-          "caption": "Settings – User",
-          "command": "open_file",
-          "args": { "file": "${packages}/User/QColor.sublime-settings" }
-        },
-        { "caption": "-", "id": "keymap" },
-        {
-          "caption": "Key Bindings",
-          "command": "edit_settings",
-          "args": {
-            "base_file": "${packages}/QColor/Default (${platform}).sublime-keymap",
-            "default": "[\n\t$0\n]\n"
-          }
-        },
-        { "caption": "-", "id": "info" },
-        { "command": "q_color_version" },
-      ]
-    }]
-  },
-  {
-    "id": "preferences",
-    "mnemonic": "p",
-    "children": [
-    {
-      "caption": "Package Settings",
-      "mnemonic": "P",
-      "id": "package-settings",
-      "children": [
-      {
-        "caption": "QColor",
-        "mnemonic": "c",
-        "children": [
-          {
-            "caption": "Settings",
-            "command": "edit_settings",
-            "args":
-            {
-              "base_file": "${packages}/QColor/QColor.sublime-settings",
-              "default": "{\n\t$0\n}\n"
-            }
-          },
-          {
-            "caption": "Settings – Default",
-            "command": "open_file",
-            "args": { "file": "${packages}/QColor/QColor.sublime-settings" }
-          },
-          {
-            "caption": "Settings – User",
-            "command": "open_file",
-            "args": { "file": "${packages}/User/QColor.sublime-settings" }
-          },
-          { "caption": "-", "id": "keymap" },
-          {
-          "caption": "Key Bindings",
-          "command": "edit_settings",
-          "args": {
-            "base_file": "${packages}/QColor/Default (${platform}).sublime-keymap",
-            "default": "[\n\t$0\n]\n"
-          }
-        },
-
-        ]
+      "children": [{
+        "caption": "Settings",
+        "command": "edit_settings",
+        "args": {"base_file":"${packages}/QColor/QColor.sublime-settings", "default":"{\n\t$0\n}\n"}
+      },{
+        "caption": "Key Bindings",
+        "command": "edit_settings",
+        "args": {"base_file":"${packages}/QColor/Default (${platform}).sublime-keymap", "default":"[\n\t$0\n]\n"}
       }]
     }]
-  }
-
-]
+  }]
+}]

--- a/Pref.sublime-menu
+++ b/Pref.sublime-menu
@@ -1,37 +1,17 @@
-[
-  { "id": "preferences",
-    "children": [
-      { "caption": "Package Settings",
-        "mnemonic": "P",
-        "id": "package-settings",
-        "children": [
-          { "caption": "QColor",
-            "children": [
-              { "caption": "README",
-                "command": "open_file",
-                "args": {
-                  "file": "${packages}/QColor/README.md"
-                }
-              },
-              { "caption": "-" },
-              { "caption": "Settings",
-                "command": "edit_settings",
-                "args": {
-                  "base_file": "${packages}/QColor/QColor.sublime-settings",
-                  "default": "{\n\t$0\n}\n"
-                }
-              },
-              { "caption": "Key Bindings",
-                "command": "edit_settings",
-                "args": {
-                  "base_file": "${packages}/QColor/Default (${platform}).sublime-keymap",
-                  "default": "[\n\t$0\n]\n"
-                }
-              },
-            ]
-          }
-        ]
-      }
-    ]
-  }
-]
+[{
+  "id": "preferences",
+  "children": [{
+    "caption": "Package Settings",
+    "mnemonic": "P",
+    "id": "package-settings",
+    "children": [{
+      "caption": "QColor",
+      "children": [
+        { "caption":"README", "command":"open_file", "args":{"file":"${packages}/QColor/README.md"}},
+        { "caption":"-" },
+        { "caption":"Settings", "command":"edit_settings", "args":{"base_file":"${packages}/QColor/QColor.sublime-settings", "default":"{\n\t$0\n}\n" }},
+        { "caption":"Key Bindings", "command":"edit_settings", "args":{"base_file":"${packages}/QColor/Default (${platform}).sublime-keymap", "default":"[\n\t$0\n]\n" }},
+      ]
+    }]
+  }]
+}]

--- a/QColor.py
+++ b/QColor.py
@@ -2,42 +2,22 @@ import sublime
 import sublime_plugin
 import os
 import subprocess
-import sys
-import re
-from pprint import pprint
+from datetime import datetime
+from .lib.qutils import QColorUtils
 
 # GLOBALS
 APPNAME = "QColor"
 VERSION = "1.0.8"
-
 SETTINGSFILE = "QColor.sublime-settings"
 CONF_KEY = "q_color"
-
 FOUND_WEBVIEW = False
-
-def SETTINGS():
-    return sublime.load_settings(SETTINGSFILE)
-
-def DEBUG():
-    return sublime.load_settings(SETTINGSFILE).get("__debug", True)
-
-def ENABLED():
-    return sublime.load_settings(SETTINGSFILE).get("_enabled", False)
-
-
-if DEBUG():
-    print("DEBUG MODE!")
-
+SETTINGS = lambda: sublime.load_settings(SETTINGSFILE)
+DEBUG = lambda: sublime.load_settings(SETTINGSFILE).get("__debug", True)
+ENABLED = lambda: sublime.load_settings(SETTINGSFILE).get("_enabled", False)
 
 # LIBS
 directory = os.path.dirname(os.path.realpath(__file__))
 libdir = os.path.join(directory, 'lib')
-
-# if libdir not in sys.path:
-    # sys.path.append(libdir)
-# print(sys.path)
-
-
 if sublime.platform() == 'osx':
     binpath = os.path.join(libdir, 'picker.py')
 elif sublime.platform() == 'linux':
@@ -47,178 +27,125 @@ elif sublime.platform() == 'windows':
 else:
     binpath = os.path.join(libdir, 'picker.py')
 
+# WARN IF DEBUG ENABLED
+if DEBUG():
+    print("DEBUG MODE!")
+
 
 def check_deps():
     test_bin = os.path.join(libdir, 'test.py')
     # if sublime.platform() == 'osx' or sublime.platform() == 'linux':
     #     if not os.access(test_bin, os.X_OK):
     #         os.chmod(test_bin, 0o755)
-
     args = [os.path.join(sublime.packages_path(), test_bin)]
     if sublime.platform() == 'windows':
         args = ['pythonw', args[0]]
     elif sublime.platform() == 'osx' or sublime.platform() == 'linux':
         args = ['python3', args[0]]
-
     if DEBUG(): print("Args:", args)
     proc = subprocess.Popen(args, stdout=subprocess.PIPE)
     msg = proc.communicate()[0].strip()
     msg = msg.decode('utf-8')
     # print(msg == "true")
-
     if msg == "true": return True
     else: return False
-
 
 
 def plugin_loaded():
     global FOUND_WEBVIEW
     if sublime.platform() == 'osx' or sublime.platform() == 'linux':
         binfile = os.path.join(sublime.packages_path(), binpath)
-        if os.path.isfile(binfile): 
-            pass
+        if os.path.isfile(binfile):
             # print("BINFILE:", binfile)
             # if not os.access(binfile, os.X_OK):
-                # os.chmod(binfile, 0o755)
-        else: print("BINFILE Not Found:", binfile)
-
+            #     os.chmod(binfile, 0o755)
+            pass
+        else:
+            print("BINFILE Not Found:", binfile)
         # print(check_deps())
-        
-        
-
     if check_deps():
         FOUND_WEBVIEW = True
     else:
         FOUND_WEBVIEW = False
-
     if not FOUND_WEBVIEW:
         print("WEBVIEW NOT FOUND: please run pip3 install pywebview")
 
 
-# for module in sys.modules.keys():
-    # if 'qutils' in module:
-        # print(module, sys.modules[module])
-        # imp.reload(sys.modules[module])
-
-from .lib.qutils import QColorUtils
-
-
-
-
-
+# -----------------------
 # HTML for Phantom
+# -----------------------
+
 def GenPhantomHTML(color, href, circular = False):
     style = """
-             * {{ background-color:transparent; border-width:0; margin:0; padding:0; }}
-          html {{ background-color:transparent;  }}
-          body {{ font-size: inherit; border-color: inherit; display:block; line-height: 1em; }}
-          
-     .circular {{ border-radius: 0.5em; }}
-
-            a {{ border: 0.05rem solid; 
-                 border-color: color({0} l(+90%) s(0%) a(0.15));
-                 border-radius: 0.0em;
-                 display:block; 
-                 text-decoration:none; 
-                 padding:-0px;
-                 width: 0.95rem; 
-                 height:0.95rem;
-                 margin-top: 0.01rem;
-                 background-color:{0};
-              }}
-
-           img {{ width: inherit; height: inherit; display:inline; position: relative;}}
-        """
-
-    content = '<a class="{1}" href="{0}"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="></a>'
-
+        *         {{ background-color:transparent; border-width:0; margin:0; padding:0; }}
+        html      {{ background-color:transparent;  }}
+        body      {{ font-size: inherit; border-color: inherit; display:block; line-height: 1em; }}
+        .circular {{ border-radius: 0.5em; }}
+        a         {{ border: 0.05rem solid; border-color: color({0} l(+90%) s(0%) a(0.15));
+                     border-radius: 0.0em; display:block; text-decoration:none; padding:-0px;
+                     width: 0.95rem; height:0.95rem; margin-top: 0.01rem; background-color:{0}; }}
+        img       {{ width: inherit; height: inherit; display:inline; position: relative; }}
+    """
+    content = '<a class="{1}" href="{0}"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="></a>'  # noqa
     html = '<body id="qcolor_phantom"><style>{0}</style>{1}</body>'
-
-
     return html.format(style.format(color), content.format(href, "circular" if circular else ""))
 
 
 def GenPopupHTML(color, colors, reg):
     global FOUND_WEBVIEW
-
     lines = ""
     for c in colors:
-        lines += '<div class="line"><a class="color" href="r:{1}:{0}">{0}</a> <a class="copy" href="copy:{1}:{0}">Copy</a></div>'.format(c, reg)
-
-    png_trans = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
-    png_green = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-
-    
+        lines += '<div class="line"><a class="color" href="r:{1}:{0}">{0}</a> <a class="copy" href="copy:{1}:{0}">Copy</a></div>'.format(c, reg)  # noqa
+    png_trans = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="  # noqa
+    png_green = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="  # noqa
     title = '<div class="title">QColor</div>'
     if FOUND_WEBVIEW:
         picker = '<a class="picker" href="{0}:{1}:">Customize</a>'.format('pick', reg)
     else:
         picker = '<span class="error">please run pip3 install pywebview</span>'
-
     preview = '<div class="preview"><img src="{0}"></div>'.format(png_trans)
-
     header = '<div class="header hl">{0} {1} {2}</div>'.format(preview, title, picker)
-
     stitle = '<div class="stitle">Convert to:</div>'
-    content = '<div class="content">{0}{1}</div>'.format(stitle, lines)    
-
+    content = '<div class="content">{0}{1}</div>'.format(stitle, lines)
     style = """
-        html     {  --margin:0.5em; 
-                    --background: hsla(210, 4%, 13%, 1); 
-                    --background: hsla(220, 13%, 14%, 1); 
-                    --foreground: hsla(215, 7%, 55%, 1); 
-                    --border: color(var(--background) l(50%) a(0.18));
-                    --border-link: color(var(--foreground) a(0.5));
-                    --bg-hl: color(var(--background) l(-50%) a(0.3));
-                   color:var(--foreground); background-color: var(--background); border: 1px solid var(--border); border-radius: 0px;
-                   }
+        html     { --margin:0.5em;
+                   --background: hsla(210, 4%, 13%, 1);
+                   --background: hsla(220, 13%, 14%, 1);
+                   --foreground: hsla(215, 7%, 55%, 1);
+                   --border: color(var(--background) l(50%) a(0.18));
+                   --border-link: color(var(--foreground) a(0.5));
+                   --bg-hl: color(var(--background) l(-50%) a(0.3));
+                   color:var(--foreground); background-color: var(--background);
+                   border: 1px solid var(--border); border-radius: 0px; }
         body     { font-family: monospace; font-size: 1rem; padding: 0; margin:0;  border-radius: inherit; }
         a        { text-decoration:none; font-size: 1em; background-color: color(red a(0.0)); color:var(--foreground); }
         img      { display: inline; position: relative; width: 1em; height: 0.8em;  line-height: 1em; }
-
-        .title   { display: inline; position: relative; font-size: 1.2em; font-weight: bold; 
+        .title   { display: inline; position: relative; font-size: 1.2em; font-weight: bold;
                    background-color: color(cyan a(0.0)); line-height: 1em;
-                   bottom: 0.15em;
-                   }
+                   bottom: 0.15em; }
         .picker  { display: inline; position: relative; font-size: 1em;
                    background-color: color(black a(0.0)); padding: 0.0em;
-                   bottom: 0.25em; line-height: 1em; border-bottom: 1px solid var(--border-link); 
-                   }
-        .preview { display: inline; position: relative; font-size: 1.8em; font-family: Helvetica;                
-                   padding: 0em 0 0 0; margin: 0 0 0 0; line-height: 1em;                 
+                   bottom: 0.25em; line-height: 1em; border-bottom: 1px solid var(--border-link); }
+        .preview { display: inline; position: relative; font-size: 1.8em; font-family: Helvetica;
+                   padding: 0em 0 0 0; margin: 0 0 0 0; line-height: 1em;
                    background-color: color(red a(0.5));
-                   border: 1px solid var(--border);  
-                   }
-
+                   border: 1px solid var(--border); }
         .error   { display: inline; position: relative; padding: 0.0em; bottom: 0.25em;
-                   font-size: 1.0em; line-height: 1em; font-weight: bold; color:red;  
-                   
-                  }
-
+                   font-size: 1.0em; line-height: 1em; font-weight: bold; color:red; }
         .stitle  { font-size: 1.0em; line-height: 1em; font-weight: bold; margin-bottom: 0.4em; }
         .line    { font-size: 1.0em; line-height: 1em; margin: 0.3em var(--margin); }
         .color   { background-color: color(black a(0.0)); padding: 0.0em; border-bottom: 1px solid var(--border-link); }
         .copy    { position: relative; font-size: 0.7em; bottom:0.15em; color: color(var(--foreground) a(0.7));
                    background-color: var(--bg-hl); padding: 0.1em 0.2em; }
-
-
         .header  { display: block; padding: var(--margin); margin: 0.0em 0.0em 0.0em 0.0em;
-                   border-top-left-radius: inherit; border-top-right-radius: inherit;
-                   }
-        .content { display: block; padding: var(--margin); margin: 0.0em 0.0em 0.0em;  
+                   border-top-left-radius: inherit; border-top-right-radius: inherit; }
+        .content { display: block; padding: var(--margin); margin: 0.0em 0.0em 0.0em;
                    background-color: color(hotpink a(0.00));
-                   border-bottom-left-radius: inherit; border-bottom-right-radius: inherit;
-                   }
-
-        
-        .hl { background-color: var(--bg-hl); }
+                   border-bottom-left-radius: inherit; border-bottom-right-radius: inherit; }
+        .hl      { background-color: var(--bg-hl); }
     """
-
-    style2 = '.preview {{ background-color: {0};}}'.format(color);
-
-
+    style2 = '.preview {{ background-color: {0};}}'.format(color)
     html = '<body id="qcolor_popup"><style>{0}</style>{1}{2}</body>'.format(style + style2, header, content)
-
     return html
 
 
@@ -229,7 +156,6 @@ def popup_navigate(view, arg):
         view.run_command("q_color_converter", {"reg": reg, "mode": "r", "value": value})
     elif cmd == 'pick':
         view.run_command("q_color_picker", {"reg": reg})
-
     elif cmd == 'copy':
         sublime.set_clipboard(value)
         sublime.status_message('Color copied to clipboard')
@@ -239,65 +165,47 @@ def popup_show(view, reg):
     if not isinstance(reg, sublime.Region):
         reg = (lambda t: sublime.Region(t[0], t[1]))(eval(reg))
     color = view.substr(reg).strip()
-
-    colors = QColorUtils().parse(color).getAll()    
-   
-    view.show_popup(GenPopupHTML(color, colors, reg), 
-                    sublime.COOPERATE_WITH_AUTO_COMPLETE,
-                    # sublime.HIDE_ON_MOUSE_MOVE |
-                    # sublime.HIDE_ON_MOUSE_MOVE_AWAY,
-                    location=reg.end(),
-                    max_width=1024,
-                    max_height=1024,
-                    # on_hide = lambda: print("HIDE POPUP") ,
-                    on_navigate=lambda x: popup_navigate(view, x))
+    colors = QColorUtils().parse(color).getAll()
+    view.show_popup(GenPopupHTML(color, colors, reg),
+        sublime.COOPERATE_WITH_AUTO_COMPLETE,
+        # sublime.HIDE_ON_MOUSE_MOVE |
+        # sublime.HIDE_ON_MOUSE_MOVE_AWAY,
+        location=reg.end(),
+        max_width=1024,
+        max_height=1024,
+        # on_hide = lambda: print("HIDE POPUP") ,
+        on_navigate=lambda x: popup_navigate(view, x))
     
 
-
-
-
-
 class QPicker(object):
-    # def __init__(self, arg):
-        # super(QPicker, self).__init__()
-        # self.arg = arg
 
     def pick(self, window, start_color):
         if DEBUG(): print("STARTCOLOR", start_color)
         ncolor = ''
-
         if sublime.platform() == 'osx' or sublime.platform() == 'linux' or sublime.platform() == 'windows':
             args = [os.path.join(sublime.packages_path(), binpath)]
             if sublime.platform() == 'windows':
                 args = ['pythonw', args[0]]
             elif sublime.platform() == 'osx' or sublime.platform() == 'linux':
                 args = ['python3', args[0]]
-
             if start_color: args.append(start_color)
-
             proc = subprocess.Popen(args, stdout=subprocess.PIPE)
             color = proc.communicate()[0].strip()
             if DEBUG(): print("RAW", color)
             ncolor = color.decode('utf-8')
-
-        else: 
+        else:
             print("PLATAFORM NOT SUPPORTED")
-
         return ncolor
 
         
-
 class QColor(sublime_plugin.ViewEventListener):
     enabled = False
-    key_conf = CONF_KEY 
+    key_conf = CONF_KEY
     key_ctrl = "active"
-
-    
-
 
     def __init__(self, view):
         self.view = view
-        self.view.QColor = self        
+        self.view.QColor = self
         self.set_conf_change()
         self.on_conf_change()
 
@@ -309,9 +217,7 @@ class QColor(sublime_plugin.ViewEventListener):
         _conf = self.view.settings().get(self.key_conf, SETTINGS().get(self.key_conf, {}))
         return _conf.get(self.key_ctrl, True)
     
-
     def start(self):
-
         # Load Settings
         self.enabled = SETTINGS().get('enabled', False)
         self.circular_phantom = self.settings().get('circular_phantom', False)
@@ -320,30 +226,17 @@ class QColor(sublime_plugin.ViewEventListener):
         named_colors = self.settings().get('named_colors', False)
         hsl_float = self.settings().get('hsl_float', True)
         hex_upper = self.settings().get('hex_upper_case', False)
-
-        
-
-
         QColorUtils.set_conf(hsl_float, hex_upper, named_colors)
-
         self.pset = sublime.PhantomSet(self.view, self.key_conf)
-
         # Restart Binds
         self.set_view_change()
         self.on_view_change()
-
-
-
-        
-
-        
 
     # File Conf Handlers
 
     def on_conf_change(self):
         # print("QColor", "on_conf_change")
         self.start()
-
 
     def set_conf_change(self):
         # print("QColor", "set_conf_change")
@@ -356,7 +249,6 @@ class QColor(sublime_plugin.ViewEventListener):
         key_id = "{0}_{1}".format(self.key_conf, self.view.id())
         self.settings().clear_on_change(key_id)
 
-
     # View Conf Handlers
 
     def on_view_change(self):
@@ -366,75 +258,54 @@ class QColor(sublime_plugin.ViewEventListener):
     def set_view_change(self):
         self.clear_view_change()
         key_id = "{0}_{1}".format(self.key_conf, self.view.id())
-        self.view.settings().add_on_change(key_id, self.on_view_change) 
+        self.view.settings().add_on_change(key_id, self.on_view_change)
 
     def clear_view_change(self):
         key_id = "{0}_{1}".format(self.key_conf, self.view.id())
         self.view.settings().clear_on_change(key_id)
 
-
-
     # Functions
 
     def getColorRegions(view):
-
         c_regions = []
         for key, value in QColorUtils.regex.items():
             # print(key)
             c_regions += view.find_all(value, sublime.IGNORECASE)
-
-
         return c_regions
-
-
 
     def phantom_navigate(view, reg):
         popup_show(view, reg)
 
     def phantom_show(self, view, reg):
         selected = view.substr(reg).strip()
-
-        view.add_phantom(self.key_conf, 
-                         sublime.Region(reg.b, reg.b), 
-                         GenPhantomHTML(selected, reg, self.circular_phantom), 
-                         sublime.LAYOUT_INLINE,
-                         on_navigate=lambda x: QColor.phantom_navigate(self.view, x))
-
-   
+        view.add_phantom(self.key_conf,
+            sublime.Region(reg.b, reg.b),
+            GenPhantomHTML(selected, reg, self.circular_phantom),
+            sublime.LAYOUT_INLINE,
+            on_navigate=lambda x: QColor.phantom_navigate(self.view, x))
 
     def show_phantoms(self, only_regions = False):
         # print("QColor", "show_phantoms")
         self.view.erase_regions(self.key_conf)
         self.view.erase_phantoms(self.key_conf)
-
-
         if not self.isEnabled(): return False
-
-
         c_regions = QColor.getColorRegions(self.view)
-
-    # "region.redish", "region.orangish", "region.yellowish", "region.greenish", "region.bluish", 
-    # "region.purplish", "region.pinkish", "region.blackish"
-        self.view.add_regions(self.key_conf, c_regions, "region.purplish", "", 
-                              # sublime.DRAW_EMPTY | 
-                              # sublime.HIDE_ON_MINIMAP | 
-                              # sublime.DRAW_EMPTY_AS_OVERWRITE | 
-                              sublime.DRAW_NO_FILL | 
-                              sublime.DRAW_NO_OUTLINE |
-                              sublime.DRAW_SOLID_UNDERLINE | 
-                              sublime.DRAW_STIPPLED_UNDERLINE | 
-                              # sublime.DRAW_SQUIGGLY_UNDERLINE | 
-                              # sublime.HIDDEN |  
-                              sublime.PERSISTENT)
-
-
-        if(not only_regions):
+        # "region.redish", "region.orangish", "region.yellowish", "region.greenish", "region.bluish",
+        # "region.purplish", "region.pinkish", "region.blackish"
+        self.view.add_regions(self.key_conf, c_regions, "region.purplish", "",
+            # sublime.DRAW_EMPTY |
+            # sublime.HIDE_ON_MINIMAP |
+            # sublime.DRAW_EMPTY_AS_OVERWRITE |
+            sublime.DRAW_NO_FILL |
+            sublime.DRAW_NO_OUTLINE |
+            sublime.DRAW_SOLID_UNDERLINE |
+            sublime.DRAW_STIPPLED_UNDERLINE |
+            # sublime.DRAW_SQUIGGLY_UNDERLINE |
+            # sublime.HIDDEN |
+            sublime.PERSISTENT)
+        if not only_regions:
             for reg in c_regions:
                 self.phantom_show(self.view, reg)
-
-
-
-
 
     def find_region(self, position):
         regions = self.view.get_regions(self.key_conf)
@@ -443,13 +314,12 @@ class QColor(sublime_plugin.ViewEventListener):
                 return True, creg
         return False, None
 
-
     # Events
+
     def on_modified(self):
         # if DEBUG(): print("View Modified")
         if self.isEnabled():
             if DEBUG(): print("View Modified")
-
         self.show_phantoms(self.hover_preview)
         # self.view.hide_popup()
 
@@ -458,14 +328,10 @@ class QColor(sublime_plugin.ViewEventListener):
             (in_region, region) = self.find_region(point)
             if in_region:
                 # print(point, hover_zone)
-            # popup_show(self.view, region)
+                # popup_show(self.view, region)
                 self.view.erase_phantoms(self.key_conf)
                 self.phantom_show(self.view, region)
             else: self.view.erase_phantoms(self.key_conf)
-
-
-
-
 
     def on_text_command(self, p1, cmd):
         # if self.isEnabled():
@@ -473,15 +339,12 @@ class QColor(sublime_plugin.ViewEventListener):
         pass
 
 
-
-
-
-
-
-
-# --- Commands
+# -----------------------
+# Commands
+# -----------------------
 
 class QColorVersion(sublime_plugin.ApplicationCommand):
+    
     def time(self):
         return datetime.now().strftime("%H:%M:%S")
 
@@ -511,7 +374,6 @@ class QColorDebug(sublime_plugin.ApplicationCommand):
             value = self.settings().get(self.key_ctrl, False)
             self.settings().set(self.key_ctrl, not value)
             sublime.save_settings(SETTINGSFILE)
-        
 
     def is_checked(self):
         return self.settings().get(self.key_ctrl, False)
@@ -530,8 +392,6 @@ class QColorEnabled(sublime_plugin.ApplicationCommand):
             self.settings().set(self.key_ctrl, not value)
             sublime.save_settings(SETTINGSFILE)
 
-
-    
     def description(self):
         return ""
 
@@ -539,11 +399,9 @@ class QColorEnabled(sublime_plugin.ApplicationCommand):
         return self.settings().get(self.key_ctrl, False)
 
 
-
 class QColorShow(sublime_plugin.ApplicationCommand):
     key_conf = CONF_KEY
     key_ctrl = 'active'
-
 
     def settings(self):
         return sublime.load_settings(SETTINGSFILE)
@@ -551,10 +409,10 @@ class QColorShow(sublime_plugin.ApplicationCommand):
     def active_view(self):
         return sublime.active_window().active_view()
 
-    def run(self): 
+    def run(self):
         # print("QColors Command")
 
-        _conf = self.active_view().settings().get(self.key_conf, self.settings().get(self.key_conf, {}))        
+        _conf = self.active_view().settings().get(self.key_conf, self.settings().get(self.key_conf, {}))
         _conf[self.key_ctrl] = not self.is_checked()
         
         self.active_view().settings().set(self.key_conf, _conf)
@@ -590,7 +448,6 @@ class QColorConverter(sublime_plugin.TextCommand):
                 return True, creg
         return False, None
 
-
     def run(self, edit, reg = None, mode = None, value = None):
         if DEBUG(): print("QColor Converter")
         (in_region, region) = self.in_region(reg)
@@ -604,13 +461,12 @@ class QColorConverter(sublime_plugin.TextCommand):
         elif mode == 'r':
             self.view.replace(edit, region, value)
             # if self.view.is_popup_visible():
-                # tmp=sublime.Region(region.begin())
+            #     tmp=sublime.Region(region.begin())
             (in_reg, nreg) = self.find_region(sublime.Region(region.begin()))
-            if(in_reg): 
+            if(in_reg):
                 if DEBUG(): print("nreg", nreg)
                 popup_show(self.view, nreg)
 
-        
     def description(self):
         return ""
 
@@ -624,12 +480,12 @@ class QColorConverter(sublime_plugin.TextCommand):
 
 class QColorPicker(sublime_plugin.TextCommand):
 
-    def run(self, edit, reg = None): 
+    def run(self, edit, reg = None):
         # print("QColor Picker")
         sel = self.view.sel()
         region = sel[0]
         if reg:
-            tmp = eval(reg)            
+            tmp = eval(reg)
             region = sublime.Region(tmp[0], tmp[1])
             
         else:
@@ -638,16 +494,13 @@ class QColorPicker(sublime_plugin.TextCommand):
                 if creg.contains(sel[0]):
                     region = creg
                     break
-
-        if region != None:
+        if region is not None:
             color = self.view.substr(region).strip()
-
             converter = QColorUtils().parse(color)
             in_mode = converter.in_mode or "rgba"
             color = converter.getRGB()
             # print(color, in_mode)
             # return
-
             ncolor = QPicker().pick(self.view.window(), color)
             if ncolor:
                 sel.clear()

--- a/QColor.py
+++ b/QColor.py
@@ -75,20 +75,21 @@ def plugin_loaded():
 # HTML for Phantom
 # -----------------------
 
-def GenPhantomHTML(color, href, circular=False):
+def GenPhantomHTML(color, href, phantom_shape='circle'):
     style = """
-        *         {{ background-color:transparent; border-width:0; margin:0; padding:0; }}
-        html      {{ background-color:transparent;  }}
-        body      {{ font-size: inherit; border-color: inherit; display:block; line-height: 1em; }}
-        .circular {{ border-radius: 0.5em; }}
-        a         {{ border: 0.05rem solid; border-color: color({0} l(+90%) s(0%) a(0.15));
+        *       {{ background-color:transparent; border-width:0; margin:0; padding:0; }}
+        html    {{ background-color:transparent;  }}
+        body    {{ font-size: inherit; border-color: inherit; display:block; line-height: 1em; }}
+        .circle {{ border-radius: 0.5em; }}
+        a       {{ border: 0.05rem solid; border-color: color({0} l(+90%) s(0%) a(0.15));
                      border-radius: 0.0em; display:block; text-decoration:none; padding:-0px;
                      width: 0.95rem; height:0.95rem; margin-top: 0.01rem; background-color:{0}; }}
-        img       {{ width: inherit; height: inherit; display:inline; position: relative; }}
+        img     {{ width: inherit; height: inherit; display:inline; position: relative; }}
     """
     content = '<a class="{1}" href="{0}"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="></a>'  # noqa
     html = '<body id="qcolor_phantom"><style>{0}</style>{1}</body>'
-    return html.format(style.format(color), content.format(href, "circular" if circular else ""))
+    clsname = phantom_shape.lower()
+    return html.format(style.format(color), content.format(href, clsname))
 
 
 def GenPopupHTML(color, colors, reg):
@@ -220,14 +221,15 @@ class QColor(sublime_plugin.ViewEventListener):
     def start(self):
         # Load Settings
         self.enabled = SETTINGS().get('enabled', False)
-        self.circular_phantom = self.settings().get('circular_phantom', False)
+        self.phantom_shape = self.settings().get('phantom_shape', "circle")
         self.hover_preview = self.settings().get('hover_preview', False)
+        # Util settings
         named_colors = self.settings().get('named_colors', False)
         hsl_float = self.settings().get('hsl_float', True)
         hex_upper = self.settings().get('hex_upper_case', False)
         QColorUtils.set_conf(hsl_float, hex_upper, named_colors)
-        self.pset = sublime.PhantomSet(self.view, self.key_conf)
         # Restart Binds
+        self.pset = sublime.PhantomSet(self.view, self.key_conf)
         self.set_view_change()
         self.on_view_change()
 
@@ -279,7 +281,7 @@ class QColor(sublime_plugin.ViewEventListener):
         selected = view.substr(reg).strip()
         view.add_phantom(self.key_conf,
             sublime.Region(reg.b, reg.b),
-            GenPhantomHTML(selected, reg, self.circular_phantom),
+            GenPhantomHTML(selected, reg, self.phantom_shape),
             sublime.LAYOUT_INLINE,
             on_navigate=lambda x: QColor.phantom_navigate(self.view, x))
 

--- a/QColor.py
+++ b/QColor.py
@@ -75,7 +75,7 @@ def plugin_loaded():
 # HTML for Phantom
 # -----------------------
 
-def GenPhantomHTML(color, href, circular = False):
+def GenPhantomHTML(color, href, circular=False):
     style = """
         *         {{ background-color:transparent; border-width:0; margin:0; padding:0; }}
         html      {{ background-color:transparent;  }}
@@ -222,7 +222,6 @@ class QColor(sublime_plugin.ViewEventListener):
         self.enabled = SETTINGS().get('enabled', False)
         self.circular_phantom = self.settings().get('circular_phantom', False)
         self.hover_preview = self.settings().get('hover_preview', False)
-        self.auto_close_popups = self.settings().get('auto_close_popups', True)
         named_colors = self.settings().get('named_colors', False)
         hsl_float = self.settings().get('hsl_float', True)
         hex_upper = self.settings().get('hex_upper_case', False)

--- a/QColor.py
+++ b/QColor.py
@@ -174,7 +174,7 @@ def popup_show(view, reg):
         location=reg.end(),
         max_width=1024,
         max_height=1024,
-        # on_hide = lambda: print("HIDE POPUP") ,
+        # on_hide = lambda: print("HIDE POPUP"),
         on_navigate=lambda x: popup_navigate(view, x))
     
 
@@ -202,7 +202,7 @@ class QPicker(object):
 class QColor(sublime_plugin.ViewEventListener):
     enabled = False
     key_conf = CONF_KEY
-    key_ctrl = "show_phantoms"
+    key_ctrl = 'phantoms_enabled'
 
     def __init__(self, view):
         self.view = view
@@ -228,9 +228,9 @@ class QColor(sublime_plugin.ViewEventListener):
         self.hover_preview = self.settings().get('hover_preview', False)
         # Util settings
         named_colors = self.settings().get('named_colors', False)
-        hsl_float = self.settings().get('hsl_float', True)
+        hsl_precision = self.settings().get('hsl_precision', True)
         hex_upper = self.settings().get('hex_upper_case', False)
-        QColorUtils.set_conf(hsl_float, hex_upper, named_colors)
+        QColorUtils.set_conf(hsl_precision, hex_upper, named_colors)
         # Restart Binds
         self.pset = sublime.PhantomSet(self.view, self.key_conf)
         self.set_view_change()
@@ -273,7 +273,6 @@ class QColor(sublime_plugin.ViewEventListener):
     def getColorRegions(view):
         c_regions = []
         for key, value in QColorUtils.regex.items():
-            # print(key)
             c_regions += view.find_all(value, sublime.IGNORECASE)
         return c_regions
 
@@ -289,10 +288,10 @@ class QColor(sublime_plugin.ViewEventListener):
             on_navigate=lambda x: QColor.phantom_navigate(self.view, x))
 
     def show_phantoms(self, only_regions=False):
-        # print("QColor", "show_phantoms")
         self.view.erase_regions(self.key_conf)
         self.view.erase_phantoms(self.key_conf)
-        if not self.isEnabled(): return False
+        if not self.isEnabled():
+            return False
         c_regions = QColor.getColorRegions(self.view)
         underline_color = self.get_region_underline_color()
         flags = self.get_region_flags()
@@ -302,7 +301,6 @@ class QColor(sublime_plugin.ViewEventListener):
                 self.phantom_show(self.view, reg)
 
     def get_region_underline_color(self):
-        # Defualt is purple
         if self.underline_color == 'red': return 'region.redish'
         if self.underline_color == 'orange': return 'region.orangish'
         if self.underline_color == 'yellow': return 'region.yellowish'
@@ -310,7 +308,7 @@ class QColor(sublime_plugin.ViewEventListener):
         if self.underline_color == 'blue': return 'region.bluish'
         if self.underline_color == 'pink': return 'region.pinkish'
         if self.underline_color == 'black': return 'region.blackish'
-        return 'region.purplish'
+        return 'region.purplish'  # Defualt purple
 
     def get_region_flags(self):
         # Make sure the underline style is one we understand
@@ -333,15 +331,18 @@ class QColor(sublime_plugin.ViewEventListener):
     # Events
 
     def on_modified(self):
-        # if DEBUG(): print("View Modified")
-        if self.isEnabled():
-            if DEBUG(): print("View Modified")
+        if DEBUG:
+            print('on_modified')
         self.show_phantoms(self.hover_preview)
-        # self.view.hide_popup()
+
+    def on_load(self):
+        if DEBUG:
+            print('on_load')
+        self.show_phantoms(self.hover_preview)
 
     def on_hover(self, point, hover_zone):
         if self.hover_preview:
-            (in_region, region) = self.find_region(point)
+            in_region, region = self.find_region(point)
             if in_region:
                 # print(point, hover_zone)
                 # popup_show(self.view, region)
@@ -351,7 +352,7 @@ class QColor(sublime_plugin.ViewEventListener):
 
     def on_text_command(self, p1, cmd):
         # if self.isEnabled():
-        # print("text cmd", p1, cmd)
+        #     print("text cmd", p1, cmd)
         pass
 
 
@@ -417,7 +418,7 @@ class QColorEnabled(sublime_plugin.ApplicationCommand):
 
 class QColorShow(sublime_plugin.ApplicationCommand):
     key_conf = CONF_KEY
-    key_ctrl = 'show_phantoms'
+    key_ctrl = 'phantoms_enabled'
 
     def settings(self):
         return sublime.load_settings(SETTINGSFILE)

--- a/QColor.sublime-commands
+++ b/QColor.sublime-commands
@@ -6,9 +6,6 @@
   { "caption":"QColor: Toggle Colors", "command":"q_color_show" },
   { "caption":"QColor: Converter", "command":"q_color_converter" },
   
-  // Debug Options
-  //{ "caption":"QColor: Toggle Plugin", "command":"q_color_enabled" },
-
   // Settings and Key Bindings
   { "caption":"QColor: Settings", "command":"edit_settings", "args": {
       "base_file":"${packages}/QColor/QColor.sublime-settings",
@@ -16,4 +13,7 @@
   { "caption":"QColor: Key Bindings", "command":"edit_settings", "args": {
       "base_file":"${packages}/QColor/Default (${platform}).sublime-keymap",
       "default":"[\n\t$0\n]\n" }}
+
+  // Debug Options
+  //{ "caption":"QColor: Toggle Plugin", "command":"q_color_enabled" },
 ]

--- a/QColor.sublime-commands
+++ b/QColor.sublime-commands
@@ -1,35 +1,12 @@
 [
-    {
-        "caption": "QColor: Picker",
-        "command": "q_color_picker"
-    },
-    {
-        "caption": "QColor: Toogle",
-        "command": "q_color_enabled"
-    },
-    {
-        "caption": "QColor: Show",
-        "command": "q_color_show"
-    },
-    {
-        "caption": "QColor: Converter",
-        "command": "q_color_converter"
-    },
-    {
-        "caption": "QColor: Settings",
-        "command": "edit_settings",
-        "args": {
-            "base_file": "${packages}/QColor/QColor.sublime-settings",
-            "default": "{\n\t$0\n}\n"
-        }
-    },
-    {
-        "caption": "QColor: Key Bindings",
-        "command": "edit_settings",
-        "args": {
-            "base_file": "${packages}/QColor/Default (${platform}).sublime-keymap",
-            "default": "[\n\t$0\n]\n"
-        }
-    }
-
+  { "caption":"QColor: Picker", "command":"q_color_picker"},
+  { "caption":"QColor: Toogle", "command":"q_color_enabled" },
+  { "caption":"QColor: Show", "command":"q_color_show" },
+  { "caption":"QColor: Converter", "command":"q_color_converter" },
+  { "caption":"QColor: Settings", "command":"edit_settings", "args": {
+      "base_file": "${packages}/QColor/QColor.sublime-settings",
+      "default": "{\n\t$0\n}\n" }},
+  { "caption":"QColor: Key Bindings", "command":"edit_settings", "args": {
+      "base_file": "${packages}/QColor/Default (${platform}).sublime-keymap",
+      "default": "[\n\t$0\n]\n" }}
 ]

--- a/QColor.sublime-commands
+++ b/QColor.sublime-commands
@@ -1,12 +1,19 @@
 [
+  // Main Options
   { "caption":"QColor: Picker", "command":"q_color_picker"},
-  { "caption":"QColor: Toogle", "command":"q_color_enabled" },
-  { "caption":"QColor: Show", "command":"q_color_show" },
+  { "caption":"QColor: Show Colors", "command":"q_color_show", "args":{"show":true} },
+  { "caption":"QColor: Hide Colors", "command":"q_color_show", "args":{"show":false} },
+  { "caption":"QColor: Toggle Colors", "command":"q_color_show" },
   { "caption":"QColor: Converter", "command":"q_color_converter" },
+  
+  // Debug Options
+  //{ "caption":"QColor: Toggle Plugin", "command":"q_color_enabled" },
+
+  // Settings and Key Bindings
   { "caption":"QColor: Settings", "command":"edit_settings", "args": {
-      "base_file": "${packages}/QColor/QColor.sublime-settings",
-      "default": "{\n\t$0\n}\n" }},
+      "base_file":"${packages}/QColor/QColor.sublime-settings",
+      "default":"{\n\t$0\n}\n" }},
   { "caption":"QColor: Key Bindings", "command":"edit_settings", "args": {
-      "base_file": "${packages}/QColor/Default (${platform}).sublime-keymap",
-      "default": "[\n\t$0\n]\n" }}
+      "base_file":"${packages}/QColor/Default (${platform}).sublime-keymap",
+      "default":"[\n\t$0\n]\n" }}
 ]

--- a/QColor.sublime-settings
+++ b/QColor.sublime-settings
@@ -6,10 +6,10 @@
   "_enabled": true,
   "q_color": { "active": false },
 
-  // Circular Phantom
-  // Set false to display square color boxes.
-  // Set true to display circular color boxes.
-  "circular_phantom": true,
+  // Phantom Shape
+  // Shape of the color phantom displayed.
+  // Available shapes are "square" and "circle"
+  "phantom_shape": "circle",
 
   // HSL Float
   // by default the HSL color space will use full integers. Setting this

--- a/QColor.sublime-settings
+++ b/QColor.sublime-settings
@@ -6,9 +6,9 @@
   "_enabled": true,
 
   // Color Phantoms
-  // show_phantoms: Show ot hide the color phantoms
+  // phantoms_enabled: Show or hide the color phantoms
   // phantom_shape: Phantom shape. One of: square, circle
-  "show_phantoms": false,
+  "phantoms_enabled": false,
   "phantom_shape": "circle",
 
   // Highlight Region
@@ -20,23 +20,13 @@
   "underline_style": "stippled",
   "underline_color": "purple",
 
-  // HSL Float
-  // By default the HSL color space will use full integers. Setting this
-  // value to true will enable a floating point presion to 3 decimal places.
-  "hsl_float": false,
-
-  // HEX Upper Case
-  // Display hex values in upper case.
+  // Misc Options
+  // hsl_precision: Number of decimal places in HSL precision.
+  // hex_upper_case: Display hex values in upper case.
+  // hover_preview: Show preview when mousing over a color.
+  // named_colors: Enable color phantoms for named colors (red, blue, etc).
+  "hsl_precision": 0,
   "hex_upper_case": true,
-
-  // Hover Preview
-  // Setting this to true will enable a color preview when hovering over a
-  // color. Only one color will be displayed on the screen at any point.
   "hover_preview": false,
-
-  // Named Colors
-  // Enable color boxes for named colors such as red, blue. The list of
-  // named colors comes from the SVG named colors. You can see them at
-  // https://www.december.com/html/spec/colorsvg.html
   "named_colors": false
 }

--- a/QColor.sublime-settings
+++ b/QColor.sublime-settings
@@ -1,18 +1,27 @@
 {
   // Internal Settings - Do not change these
-  // You can enable or disable this plugin using the Sublime
-  // menu command "QColor: Toggle"
-  "__debug": false,
+  // _debug: Enable QColor debug mode
+  // _enabled: Enable or disable the plugin
+  "_debug": false,
   "_enabled": true,
-  "q_color": { "active": false },
 
-  // Phantom Shape
-  // Shape of the color phantom displayed.
-  // Available shapes are "square" and "circle"
+  // Color Phantoms
+  // show_phantoms: Show ot hide the color phantoms
+  // phantom_shape: Phantom shape. One of: square, circle
+  "show_phantoms": false,
   "phantom_shape": "circle",
 
+  // Highlight Region
+  // show_on_minimap: Show or hide the regions on the minimap.
+  // underline_color: Color of region underline. One of: red, orange,
+  //   yellow, green, blue, purple, pink, black.
+  // underline_style: Underline style. One of: none, solid, stippled.
+  "show_on_minimap": true,
+  "underline_style": "stippled",
+  "underline_color": "purple",
+
   // HSL Float
-  // by default the HSL color space will use full integers. Setting this
+  // By default the HSL color space will use full integers. Setting this
   // value to true will enable a floating point presion to 3 decimal places.
   "hsl_float": false,
 

--- a/QColor.sublime-settings
+++ b/QColor.sublime-settings
@@ -1,14 +1,33 @@
 {
+  // Internal Settings - Do not change these
+  // You can enable or disable this plugin using the Sublime
+  // menu command "QColor: Toggle"
   "__debug": false,
   "_enabled": true,
-  "q_color":
-  {
-    "active": false
-  },
+  "q_color": { "active": false },
+
+  // Circular Phantom
+  // Set false to display square color boxes.
+  // Set true to display circular color boxes.
   "circular_phantom": true,
+
+  // HSL Float
+  // by default the HSL color space will use full integers. Setting this
+  // value to true will enable a floating point presion to 3 decimal places.
   "hsl_float": false,
+
+  // HEX Upper Case
+  // Display hex values in upper case.
   "hex_upper_case": true,
+
+  // Hover Preview
+  // Setting this to true will enable a color preview when hovering over a
+  // color. Only one color will be displayed on the screen at any point.
   "hover_preview": false,
-  "auto_close_popups": true,
+
+  // Named Colors
+  // Enable color boxes for named colors such as red, blue. The list of
+  // named colors comes from the SVG named colors. You can see them at
+  // https://www.december.com/html/spec/colorsvg.html
   "named_colors": false
 }

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ webview.start()
   "hsl_float": false,
   "hex_upper_case": true,
   "hover_preview": false,
-  "auto_close_popups": true,
   "named_colors": false
 }
 ```

--- a/README.md
+++ b/README.md
@@ -8,28 +8,25 @@ Awesome Sublime Color Highlighter, Converter and Picker
 
 
 ## Settings
-`phantom_shape` - Shape of the color phantom displayed, "square" or "circle".
+**phantom_shape**  - Shape of the color phantom displayed, "square" or "circle".<br/>
+**hsl_precision**  - Number of decimal places in HSL precision.<br/>
+**hex_upper_case** - Display hex values in upper case.<br/>
+**hover_preview**  - Enable a color preview when hovering over a color.<br/>
+**named_colors**   - Enable phantoms for [named colors](https://www.december.com/html/spec/colorsvg.html)
+                     such as "red", "blue".<br/>
 
-`hsl_float` - Sets HSL color precision to 3 decimal places. Default is 0 decimal places.
+### Menu Options
+**QColor: Picker** - Open the pywebview color picker.<br/>
+**QColor: Show Colors** - Show color phantoms.<br/>
+**QColor: Hide Colors** - Hide color phantoms.<br/>
+**QColor: Toggle Colors** - Toggle color phantoms.<br/>
+**QColor: Settings** - Edit the QColor settings files.<br/>
+**QColor: Key Bindings** - Edit the QColor key bindings.<br/>
 
-`hex_upper_case` - Display hex values in upper case.
-
-`hover_preview` - Enable a color preview when hovering over a color.
-
-`named_colors` - Enable phantoms for named colors such as "red", "blue".
-[Available names here.](https://www.december.com/html/spec/colorsvg.html)
-
-
-## Menu Options
-`QColor: Picker` - Open the pywebview color picker.
-
-`QColor: Show` - Enable QColor plugin.
-
-`QColor: Toggle` - Enable and disable QColor plugin
-
-`QColor: Settings` - Edit the QColor settings files.
-
-`QColor: Key Bindings` - Edit the QColor key bindings.
+### Key Bindings
+`ctrl+shift+c` - Open the color picker.<br/>
+`alt+shift+c` - Open the color convertor.<br/>
+`alt+ctrl+c` - Toggle color phantoms.<br/>
 
 
 ## Screenshots

--- a/README.md
+++ b/README.md
@@ -1,41 +1,48 @@
 # QColor
 Awesome Sublime Color Highlighter, Converter and Picker 
 
+
 ## Installation
 1. `pip3 install pywebview`
 2. Restart Sublime
 
-### Possible problems
-  
-If picker dont works, maybe you having some problem with pywebview. You can try run the following python code to check if webview is working properly.
-
-```python
-
-import webview
-webview.create_window('Hello world', 'https://pywebview.flowrl.com/hello')
-webview.start()
-
-```
 
 ## Settings
-```
-{
-  "__debug": false,
-  "_enabled": true,
-  "q_color": // is used internally, it recommended not change. 
-  {
-    "active": false 
-  },
-  "circular_phantom": true,
-  "hsl_float": false,
-  "hex_upper_case": true,
-  "hover_preview": false,
-  "named_colors": false
-}
-```
+`phantom_shape` - Shape of the color phantom displayed, "square" or "circle".
+
+`hsl_float` - Sets HSL color precision to 3 decimal places. Default is 0 decimal places.
+
+`hex_upper_case` - Display hex values in upper case.
+
+`hover_preview` - Enable a color preview when hovering over a color.
+
+`named_colors` - Enable phantoms for named colors such as "red", "blue".
+[Available names here.](https://www.december.com/html/spec/colorsvg.html)
+
+
+## Menu Options
+`QColor: Picker` - Open the pywebview color picker.
+
+`QColor: Show` - Enable QColor plugin.
+
+`QColor: Toggle` - Enable and disable QColor plugin
+
+`QColor: Settings` - Edit the QColor settings files.
+
+`QColor: Key Bindings` - Edit the QColor key bindings.
+
 
 ## Screenshots
 |Picker|Converter|
 |:----:|:-------:|
 |![Screenshot from 2021-09-04 15-53-27](https://user-images.githubusercontent.com/2568375/132105273-a454bfa7-0f11-4e6b-b141-20654e36fe8c.png) | ![image](https://user-images.githubusercontent.com/2568375/109458175-0fb34c80-7a3b-11eb-8185-a92a24f98f38.png)
 
+
+## Possible problems
+If picker dont works, maybe you having some problem with pywebview. You can try
+run the following python code to check if webview is working properly.
+```python
+import webview
+webview.create_window('Hello world', 'https://pywebview.flowrl.com/hello')
+webview.start()
+```

--- a/lib/picker.py
+++ b/lib/picker.py
@@ -1,26 +1,19 @@
 #!/usr/bin/env python3
-
-import threading
-import time
 import sys
-import random
 import webview
 
-
+# TODO: This shouldn't be here
 resp = ""
 color = "#ff0000"
 toprint = False
-
 param = ''
-
 if len(sys.argv) > 1:
     param = sys.argv[1]
     # current_color.parse(param)
-
 resp = param
 color = param
-
 # print("Start: ", color)
+
 
 class Api:
     def __init__(self):
@@ -44,13 +37,11 @@ class Api:
         resp = color
         return response
 
-
-    def closeWindow(self, to_print = False):
+    def closeWindow(self, to_print=False):
         global toprint, color, resp
-        toprint = to_print;
-        
-        if to_print: print(resp)
-
+        toprint = to_print
+        if to_print:
+            print(resp)
         window.destroy()
 
     def error(self):
@@ -63,29 +54,30 @@ def on_closing():
     #    print(resp)
     pass
 
+
 def change_url(window):
     # wait a few seconds before changing url:
     # time.sleep(10)
-
     # change url:
     window.load_url('web/picker.html')
     pass
+
 
 def get_file():
     f = open("web/picker.html", "r")
     return f.read()
 
+
 if __name__ == '__main__':
     api = Api()
-    window = webview.create_window('QPicker', 
-                                   url="web/picker.html",
-                                   js_api=api, 
-                                   frameless=False,
-                                   background_color='#333333',
-                                   width=350,
-                                   height=450,
-                                   easy_drag = False,
-                                   resizable=False
-                                   )
+    window = webview.create_window('QPicker',
+       url="web/picker.html",
+       js_api=api,
+       frameless=False,
+       background_color='#333333',
+       width=350,
+       height=450,
+       easy_drag = False,
+       resizable=False)
     window.closing += on_closing
     webview.start(http_server=True)

--- a/lib/qutils.py
+++ b/lib/qutils.py
@@ -1,18 +1,13 @@
 import re
 
-class QColorUtils(object):    
-    r = 0
-    g = 0
-    b = 0
-    a = 1
+
+class QColorUtils(object):
+    r, g, b, a = 0, 0, 0, 1
     alpha = False
     in_mode = ""
-
     hsl_precision = 3
     hex_upper = True
     named_colors = False
-
-
     svg_colors = {
         "aliceblue": "F0F8FF",
         "antiquewhite": "FAEBD7",
@@ -163,22 +158,18 @@ class QColorUtils(object):
         "yellow": "FFFF00",
         "yellowgreen": "9ACD32"
     }
-
     regex = {
         "hex": r"\#([a-fA-F0-9]{8}|[a-fA-F0-9]{6}|[a-fA-F0-9]{3})\b",
-        "rgb" : r"rgb\s*?\(\s*?(000|0?\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\s*?,\s*?(000|0?\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\s*?,\s*?(000|0?\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\s*?\)",
-        "rgba" : r"rgba\s*?\(\s*?(000|0?\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\s*?,\s*?(000|0?\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\s*?,\s*?(000|0?\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\s*?,\s*?(0|0*\.\d+|1|1.0*)\s*?\)",
-        "hsl": r"hsl\s*?\(\s*?((?:000|0?\d{1,2}|[1-2]\d\d|3[0-5]\d|360)(?:\.\d*)?)\s*?,\s*?((?:000|100|0?\d{2}|0?0?\d)(?:\.\d*)?)%\s*?,\s*?((?:000|100|0?\d{2}|0?0?\d)(?:\.\d*)?)%\s*?\)",
-        "hsla": r"hsla\s*?\(\s*?((?:000|0?\d{1,2}|[1-2]\d\d|3[0-5]\d|360)(?:\.\d*)?)\s*?,\s*?((?:000|100|0?\d{2}|0?0?\d)(?:\.\d*)?)%\s*?,\s*?((?:000|100|0?\d{2}|0?0?\d)(?:\.\d*)?)%\s*?,\s*?(0|0*\.\d+|1|1.0*)\s*?\)",
+        "rgb" : r"rgb\s*?\(\s*?(000|0?\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\s*?,\s*?(000|0?\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\s*?,\s*?(000|0?\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\s*?\)",  # noqa
+        "rgba" : r"rgba\s*?\(\s*?(000|0?\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\s*?,\s*?(000|0?\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\s*?,\s*?(000|0?\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\s*?,\s*?(0|0*\.\d+|1|1.0*)\s*?\)",  # noqa
+        "hsl": r"hsl\s*?\(\s*?((?:000|0?\d{1,2}|[1-2]\d\d|3[0-5]\d|360)(?:\.\d*)?)\s*?,\s*?((?:000|100|0?\d{2}|0?0?\d)(?:\.\d*)?)%\s*?,\s*?((?:000|100|0?\d{2}|0?0?\d)(?:\.\d*)?)%\s*?\)",  # noqa
+        "hsla": r"hsla\s*?\(\s*?((?:000|0?\d{1,2}|[1-2]\d\d|3[0-5]\d|360)(?:\.\d*)?)\s*?,\s*?((?:000|100|0?\d{2}|0?0?\d)(?:\.\d*)?)%\s*?,\s*?((?:000|100|0?\d{2}|0?0?\d)(?:\.\d*)?)%\s*?,\s*?(0|0*\.\d+|1|1.0*)\s*?\)",  # noqa
     }
-    
 
-
-    # Static Functions
     def set_conf(hsl_float = False, hex_upper_case = False, named_color = False):
-        QColorUtils.hsl_precision =  3 if hsl_float else 0
-        QColorUtils.hex_upper =  True if hex_upper_case else False
-        QColorUtils.named_colors =  True if named_color else False
+        QColorUtils.hsl_precision = 3 if hsl_float else 0
+        QColorUtils.hex_upper = True if hex_upper_case else False
+        QColorUtils.named_colors = True if named_color else False
         if QColorUtils.named_colors:
             QColorUtils.regex.update({"named": r"\b(" + "|".join(list(QColorUtils.svg_colors.keys())) + r")\b"})
         
@@ -189,34 +180,29 @@ class QColorUtils(object):
         (r, g, b) = float(r), float(g), float(b)
         high = max(r, g, b)
         low = min(r, g, b)
-        h = s = l = (high + low) / 2.0
-
+        h = s = l = (high + low) / 2.0  # noqa
         if high == low:
             h = s = 0.0
         else:
             d = high - low
-            
             s = d / (2.0 - high - low) if l > 0.5 else d / (high + low)
-            
             h = {
                 r: (g - b) / d + (6.0 if g < b else 0),
                 g: (b - r) / d + 2.0,
                 b: (r - g) / d + 4.0,
             }[high]
             h /= 6.0
-
         if not normalized:
             (h, s, l) = h * 360, s * 100, l * 100
-
         return h, s, l
 
-    def hsl_to_rgb(h, s, l, normalized = False):
+    def hsl_to_rgb(h, s, l, normalized = False):  # noqa
         if not normalized:
             (h, s, l) = h / 360.0, s / 100.0, l / 100.0
 
         def hue_to_rgb(p, q, t):
             if t < 0: t += 1
-            if t > 1: t -= 1 
+            if t > 1: t -= 1
             if t < 1/6.0: return p + (q - p) * 6.0 * t
             if t < 1/2.0: return q
             if t < 2/3.0: return p + (q - p) * (2/3.0 - t) * 6.0
@@ -230,45 +216,30 @@ class QColorUtils(object):
             r = hue_to_rgb(p, q, h + 1/3.0)
             g = hue_to_rgb(p, q, h)
             b = hue_to_rgb(p, q, h - 1/3.0)
-        
-        if not normalized: 
+        if not normalized:
             (r, g, b) = r * 255, g * 255, b * 255
-
         return r, g, b
-
-
-
-    
-
-    def __init__(self):
-        pass
             
-
-    # Parse Function
-
     def parse(self, color):
         regex_hex = self.regex["hex"]
         regex_rgb = self.regex["rgb"]
         regex_rgba = self.regex["rgba"]
         regex_hsl = self.regex["hsl"]
         regex_hsla = self.regex["hsla"]
-        
         (self.r, self.g, self.b, self.a) = 0, 0, 0, 1
-
         color = color.strip().lower()
-
         if color in self.svg_colors.keys():
-            color='#'+ self.svg_colors[color].lower()
-
+            color = '#' + self.svg_colors[color].lower()
         if color.startswith('#'):
             match = re.search(regex_hex, color, re.IGNORECASE)
             if(match):
                 value = match.group(1)
-                
                 if len(value) == 3:
-                    (self.r, self.g, self.b) = int(value[0:1] + value[0:1], 16), int(value[1:2] + value[1:2], 16), int(value[2:3] + value[2:3], 16)
+                    (self.r, self.g, self.b) = (
+                        int(value[0:1] + value[0:1], 16),
+                        int(value[1:2] + value[1:2], 16),
+                        int(value[2:3] + value[2:3], 16))
                     # self.a = int(value[6:8], 16) / 255
-
                     self.alpha = True
                 elif len(value) == 8:
                     (self.r, self.g, self.b) = int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16)
@@ -277,11 +248,11 @@ class QColorUtils(object):
                 else:
                     (self.r, self.g, self.b) = int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16)
             self.in_mode = 'hex'
-            
         elif color.startswith('rgba'):
             match = re.search(regex_rgba, color, re.IGNORECASE)
             if(match):
-                (self.r, self.g, self.b, self.a) = int(match.group(1)), int(match.group(2)), int(match.group(3)), float(match.group(4))
+                (self.r, self.g, self.b, self.a) = (int(match.group(1)), int(match.group(2)),
+                    int(match.group(3)), float(match.group(4)))
                 self.alpha = True
             self.in_mode = 'rgba'
         elif color.startswith('rgb'):
@@ -292,18 +263,18 @@ class QColorUtils(object):
         elif color.startswith('hsla'):
             match = re.search(regex_hsla, color, re.IGNORECASE)
             if(match):
-                (self.r, self.g, self.b) = QColorUtils.hsl_to_rgb(float(match.group(1)), float(match.group(2)), float(match.group(3)))
+                (self.r, self.g, self.b) = QColorUtils.hsl_to_rgb(float(match.group(1)),
+                    float(match.group(2)), float(match.group(3)))
                 self.a = float(match.group(4))
                 self.alpha = True
             self.in_mode = 'hsla'
         elif color.startswith('hsl'):
             match = re.search(regex_hsl, color, re.IGNORECASE)
             if(match):
-                (self.r, self.g, self.b) = QColorUtils.hsl_to_rgb(float(match.group(1)), float(match.group(2)), float(match.group(3)))
+                (self.r, self.g, self.b) = QColorUtils.hsl_to_rgb(float(match.group(1)),
+                    float(match.group(2)), float(match.group(3)))
             self.in_mode = 'hsl'
         return self
-
-    # Get Functions
 
     def getHEX(self, alpha = False):
         resp = "#%02x%02x%02x" % (round(self.r), round(self.g), round(self.b))
@@ -312,21 +283,24 @@ class QColorUtils(object):
         return resp.upper() if self.hex_upper else resp.lower()
 
     def getRGBA(self):
-        return "rgba({0:g}, {1:g}, {2:g}, {3:g})".format(round(self.r, 0), round(self.g, 0), round(self.b, 0), round(self.a, 3))
+        return "rgba({0:g}, {1:g}, {2:g}, {3:g})".format(round(self.r, 0),
+            round(self.g, 0), round(self.b, 0), round(self.a, 3))
 
-    def getRGB(self, alpha = True):        
+    def getRGB(self, alpha = True):
         if self.alpha and alpha: return self.getRGBA()
         return "rgb({0:g}, {1:g}, {2:g})".format(round(self.r, 0), round(self.g, 0), round(self.b, 0))
     
     def getHSLA(self):
         (r, g, b) = QColorUtils.rgb_to_hsl(self.r, self.g, self.b)
-        resp = "hsla({0:g}, {1:g}%, {2:g}%, {3:g})".format(round(r, self.hsl_precision), round(g, self.hsl_precision), round(b, self.hsl_precision), round(self.a, 3))
+        resp = "hsla({0:g}, {1:g}%, {2:g}%, {3:g})".format(round(r, self.hsl_precision),
+            round(g, self.hsl_precision), round(b, self.hsl_precision), round(self.a, 3))
         return resp
 
     def getHSL(self, alpha = True):
         if self.alpha and alpha: return self.getHSLA()
         (r, g, b) = QColorUtils.rgb_to_hsl(self.r, self.g, self.b)
-        resp = "hsl({0:g}, {1:g}%, {2:g}%)".format(round(r, self.hsl_precision), round(g, self.hsl_precision), round(b, self.hsl_precision))
+        resp = "hsl({0:g}, {1:g}%, {2:g}%)".format(round(r, self.hsl_precision),
+            round(g, self.hsl_precision), round(b, self.hsl_precision))
         return resp
 
     def getNamed(self):
@@ -345,27 +319,21 @@ class QColorUtils(object):
         else: return self.get(self.in_mode, alpha)
 
     def getAll(self):
-        colors = [self.getHEX(False), self.getHEX(True), self.getRGB(False), self.getRGBA(), self.getHSL(False), self.getHSLA()]
-        
+        colors = [self.getHEX(False), self.getHEX(True), self.getRGB(False),
+            self.getRGBA(), self.getHSL(False), self.getHSLA()]
         name = self.getNamed()
         if name: colors.insert(0, name)
-
         return colors
 
     def getAllNamed(self):
         colors = {}
-        colors["hex"] =  self.getHEX(False)
-        colors["hexa"] =  self.getHEX(True)
-        colors["rgb"] =  self.getRGB(False)
-        colors["rgba"] =  self.getRGBA()
-        colors["hsl"] =  self.getHSL(False)
-        colors["hsla"] =  self.getHSLA()
-
+        colors["hex"] = self.getHEX(False)
+        colors["hexa"] = self.getHEX(True)
+        colors["rgb"] = self.getRGB(False)
+        colors["rgba"] = self.getRGBA()
+        colors["hsl"] = self.getHSL(False)
+        colors["hsla"] = self.getHSLA()
         name = self.getNamed()
-        if name: colors["name"] =  name
-
+        if name:
+            colors["name"] = name
         return colors
-
-
-
-

--- a/lib/qutils.py
+++ b/lib/qutils.py
@@ -166,7 +166,7 @@ class QColorUtils(object):
         "hsla": r"hsla\s*?\(\s*?((?:000|0?\d{1,2}|[1-2]\d\d|3[0-5]\d|360)(?:\.\d*)?)\s*?,\s*?((?:000|100|0?\d{2}|0?0?\d)(?:\.\d*)?)%\s*?,\s*?((?:000|100|0?\d{2}|0?0?\d)(?:\.\d*)?)%\s*?,\s*?(0|0*\.\d+|1|1.0*)\s*?\)",  # noqa
     }
 
-    def set_conf(hsl_float = False, hex_upper_case = False, named_color = False):
+    def set_conf(hsl_float=False, hex_upper_case=False, named_color=False):
         QColorUtils.hsl_precision = 3 if hsl_float else 0
         QColorUtils.hex_upper = True if hex_upper_case else False
         QColorUtils.named_colors = True if named_color else False
@@ -276,7 +276,7 @@ class QColorUtils(object):
             self.in_mode = 'hsl'
         return self
 
-    def getHEX(self, alpha = False):
+    def getHEX(self, alpha=False):
         resp = "#%02x%02x%02x" % (round(self.r), round(self.g), round(self.b))
         if (self.alpha and alpha) or (not self.alpha and alpha):
             resp += "%02x" % round(self.a * 255)

--- a/lib/qutils.py
+++ b/lib/qutils.py
@@ -166,8 +166,8 @@ class QColorUtils(object):
         "hsla": r"hsla\s*?\(\s*?((?:000|0?\d{1,2}|[1-2]\d\d|3[0-5]\d|360)(?:\.\d*)?)\s*?,\s*?((?:000|100|0?\d{2}|0?0?\d)(?:\.\d*)?)%\s*?,\s*?((?:000|100|0?\d{2}|0?0?\d)(?:\.\d*)?)%\s*?,\s*?(0|0*\.\d+|1|1.0*)\s*?\)",  # noqa
     }
 
-    def set_conf(hsl_float=False, hex_upper_case=False, named_color=False):
-        QColorUtils.hsl_precision = 3 if hsl_float else 0
+    def set_conf(hsl_presicion=0, hex_upper_case=False, named_color=False):
+        QColorUtils.hsl_precision = hsl_presicion
         QColorUtils.hex_upper = True if hex_upper_case else False
         QColorUtils.named_colors = True if named_color else False
         if QColorUtils.named_colors:
@@ -176,7 +176,6 @@ class QColorUtils(object):
     def rgb_to_hsl(r, g, b, normalized = False):
         if not normalized:
             (r, g, b) = r / 255.0, g / 255.0, b / 255.0
-
         (r, g, b) = float(r), float(g), float(b)
         high = max(r, g, b)
         low = min(r, g, b)
@@ -286,22 +285,25 @@ class QColorUtils(object):
         return "rgba({0:g}, {1:g}, {2:g}, {3:g})".format(round(self.r, 0),
             round(self.g, 0), round(self.b, 0), round(self.a, 3))
 
-    def getRGB(self, alpha = True):
+    def getRGB(self, alpha=True):
         if self.alpha and alpha: return self.getRGBA()
         return "rgb({0:g}, {1:g}, {2:g})".format(round(self.r, 0), round(self.g, 0), round(self.b, 0))
     
     def getHSLA(self):
-        (r, g, b) = QColorUtils.rgb_to_hsl(self.r, self.g, self.b)
-        resp = "hsla({0:g}, {1:g}%, {2:g}%, {3:g})".format(round(r, self.hsl_precision),
-            round(g, self.hsl_precision), round(b, self.hsl_precision), round(self.a, 3))
-        return resp
+        h,s,l = QColorUtils.rgb_to_hsl(self.r, self.g, self.b)
+        h,s,l,a = [round(x, self.hsl_precision) for x in (h,s,l,self.a)]
+        if self.hsl_precision == 0:
+            h,s,l,a = [int(x) for x in (h,s,l,a)]
+        return "hsla({0:g}, {1:g}%, {2:g}%, {3:g})".format(h,s,l,a)
 
-    def getHSL(self, alpha = True):
-        if self.alpha and alpha: return self.getHSLA()
-        (r, g, b) = QColorUtils.rgb_to_hsl(self.r, self.g, self.b)
-        resp = "hsl({0:g}, {1:g}%, {2:g}%)".format(round(r, self.hsl_precision),
-            round(g, self.hsl_precision), round(b, self.hsl_precision))
-        return resp
+    def getHSL(self, alpha=True):
+        if self.alpha and alpha:
+            return self.getHSLA()
+        h,s,l = QColorUtils.rgb_to_hsl(self.r, self.g, self.b)
+        h,s,l = [round(x, self.hsl_precision) for x in (h,s,l)]
+        if self.hsl_precision == 0:
+            h,s,l = [int(x) for x in (h,s,l)]
+        return "hsl({0:g}, {1:g}%, {2:g}%)".format(h,s,l)
 
     def getNamed(self):
         hex = self.getHEX(False).upper().strip('#')

--- a/lib/test.py
+++ b/lib/test.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 
 try:
-    import webview
+    import webview  # noqa
     print('true')
-except:
+except Exception:
     print('false')
-


### PR DESCRIPTION
I apologize this is a rather large pull request, I started working on one smallish change, then just kept going. If you're willing to accept a large change like this, I would recommend trying it out on your machine before accepting. The changes included are:

* Updated all python files to pass flake8 linting.
* Documented all options in QColor.sublime-settings and README.md.
* Added `on_load` event so phantoms load when first opening a file.
* Added default keybinding `alt+ctrl+c` for toggle colors. 
* Removed Default Settings and User Settings menu items. Settings opens both side by side.
* Fixed mnemonic errors on console for 'c' and 't'. Just removed them.
* Removed `PERSISTENT` option on regions. It was causing regions to stay highlighted even if QColor was uninstalled.
* Removed unused setting `auto_close_popup`. Not referenced in the code anywhere.
* New and updated options:
   * New option `underline_style` allows none, solid, or stippled.
   * New option `show_on_minimap` allows true or false.
   * New option `underline_color` allows purple, red, orange, etc.
   * Updated `circular_phantom` to `phantom_shape` allows circle or square.
   * Updated `hsl_float` to `hsl_precision` and it takes an integer (default: 0).
   * Updated `__debug` to `_debug` to match the other option.
   * Updated `q_color { active }` option to `phantoms_enabled`.
*  Updated Quick Menu options:
   * Added `QColor: Show Colors` option.
   * Added `QColor: Hide Colors` option.
   * Renamed `QColor: Show` to `QColor: Toggle Colors` and it updated `phantoms_enabled`.
   * Removed `QColor: Toggle` option, plugin should stay enabled always.

My flake8 settings were the following:
```
ignore=E128,E226,E231,E251,E401,E701,E731,E741,W293,W503,W504
```